### PR TITLE
ci: auto-merge non-major Dependabot PRs after CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /public/app
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      app-production:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      app-development:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: svelte
+        update-types: ["version-update:semver-major"]
+      - dependency-name: uuid
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    directory: /public/mud-client
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      mud-client-production:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      mud-client-development:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: svelte
+        update-types: ["version-update:semver-major"]
+      - dependency-name: svelte-feather-icons
+        update-types: ["version-update:semver-major"]
+      - dependency-name: uuid
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      go-modules:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,47 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  dependabot:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close major version bumps
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "Skipping this major Dependabot bump; it needs a dedicated migration. Patch and minor updates are auto-merged after CI.
+
+          @dependabot ignore this major version"
+          gh pr close "$PR" --repo "$GITHUB_REPOSITORY"
+
+      - name: Wait for checks and squash-merge non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # Let the Docker build check register before watching.
+          sleep 20
+          if gh pr checks "$PR" --repo "$GITHUB_REPOSITORY" --watch --fail-fast; then
+            gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --squash
+          else
+            echo "Checks failed for #$PR; leaving the PR open."
+            exit 1
+          fi

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -266,6 +266,8 @@ Planned epics (see `game-design/GAME_DESIGN.md`):
 | CI/CD | GitHub Actions |
 | Database | SQLite |
 
+Dependabot opens weekly grouped patch/minor PRs for npm (`public/app`, `public/mud-client`), Go modules, and GitHub Actions. `.github/workflows/dependabot-auto-merge.yml` waits for CI and squash-merges those PRs. Major bumps (Svelte, uuid) are ignored and must be migrated separately.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
Ongoing automation for Dependabot:

- `.github/dependabot.yml` — weekly grouped patch/minor updates for npm (app + mud-client), Go modules, and GitHub Actions. Ignores Svelte/uuid majors.
- `.github/workflows/dependabot-auto-merge.yml` — after CI, squash-merges non-major Dependabot PRs and closes major bumps.

Existing open Dependabot PRs have been squash-merged (or closed if they were Svelte 5 / uuid 14).