### PR TITLE
fix(ci): build Docker image with Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN npm run build
 # ============================================================
 # Stage 3: Build the Go binary
 # ============================================================
-FROM golang:1.24-alpine AS build-backend
+FROM golang:1.25-alpine AS build-backend
 
 WORKDIR /src
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -442,7 +442,7 @@ GROQ_API_KEY=
 ## Building & Running
 
 ### Prerequisites
-- Go 1.24+
+- Go 1.25+
 - Node.js (for frontend build)
 
 ### Build Commands

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Build immersive text-based multiplayer adventures in any genre — fantasy, sci-fi, horror, and beyond*
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://golang.org/)
 [![Svelte](https://img.shields.io/badge/Svelte-4.2-FF3E00?logo=svelte)](https://svelte.dev/)
 [![Live Demo](https://img.shields.io/badge/Demo-veilspan.com-success)](https://veilspan.com)
 
@@ -127,7 +127,7 @@ TalesMUD's **generic, reusable architecture** makes it perfect for any setting:
 
 ### 🚀 Modern Architecture
 
-- **Go 1.24** backend with Gin HTTP framework
+- **Go 1.25** backend with Gin HTTP framework
 - **Svelte 4** frontend with TailwindCSS
 - **SQLite** for persistence (simple deployment, no database server needed)
 - **WebSocket** real-time communication
@@ -141,7 +141,7 @@ TalesMUD's **generic, reusable architecture** makes it perfect for any setting:
 
 ### Prerequisites
 
-- **Go 1.24+** ([Download](https://golang.org/dl/))
+- **Go 1.25+** ([Download](https://golang.org/dl/))
 - **Node.js 18+** ([Download](https://nodejs.org/))
 - **Make** (optional, for convenience commands)
 
@@ -202,7 +202,7 @@ See [Configuration](#configuration-reference) for full details.
 ### Backend
 | Component | Technology |
 |-----------|------------|
-| Language | Go 1.24 |
+| Language | Go 1.25 |
 | HTTP Framework | Gin |
 | WebSocket | Gorilla WebSocket |
 | Database | SQLite (JSON document storage) |


### PR DESCRIPTION
## Why
Dependabot's go-modules group (#85) raised `go.mod` to `go 1.25.0`. The Docker backend stage still used `golang:1.24-alpine`, and the official image sets `GOTOOLCHAIN=local`, so master CI fails at:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

Example: run 34171570791.

## Change
- Dockerfile backend stage: `golang:1.25-alpine`
- README / PROJECT.md prerequisites aligned to Go 1.25

No application code change.